### PR TITLE
fix: unblock timely Renovate updates

### DIFF
--- a/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
+++ b/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
@@ -58,7 +58,7 @@ Expected: exit code 0.
 Run:
 
 ```bash
-npx --yes --package renovate renovate-config-validator renovate.json
+npx --yes --package renovate@latest renovate-config-validator renovate.json
 ```
 
 Expected: `Config validated successfully`.

--- a/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
+++ b/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
@@ -1,0 +1,71 @@
+# Renovate Update Timing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent Renovate updates from remaining indefinitely pending while retaining the five-day cooldown where release timestamps are available.
+
+**Architecture:** Adjust the repository-level Renovate policy for timestamp-less releases, preserve timestamps in the Portainer custom datasource, and widen the weekly branch-creation schedule. Validate both the static configuration and the transformed Portainer release data.
+
+**Tech Stack:** Renovate JSON configuration, JSONata custom datasource transform, Node.js assertions, Renovate config validator
+
+---
+
+### Task 1: Update Renovate timing policy
+
+**Files:**
+- Modify: `renovate.json:6-8`
+- Modify: `renovate.json:59-61`
+
+- [ ] **Step 1: Verify the current configuration lacks the required behavior**
+
+Run:
+
+```bash
+node -e 'const c=require("./renovate.json"); if(c.minimumReleaseAgeBehaviour!=="timestamp-optional") throw new Error("timestamp behavior not configured"); if(c.schedule?.[0]!=="* 10-13 * * 5") throw new Error("schedule not widened");'
+```
+
+Expected: FAIL with `timestamp behavior not configured`.
+
+- [ ] **Step 2: Configure release-age behavior and schedule**
+
+Add the following beside `minimumReleaseAge`:
+
+```json
+"minimumReleaseAgeBehaviour": "timestamp-optional",
+"schedule": ["* 10-13 * * 5"],
+```
+
+- [ ] **Step 3: Preserve the Portainer release timestamp**
+
+Change the Portainer transform to emit:
+
+```json
+{ "version": $v.tag_name, "releaseTimestamp": $v.published_at, "sourceUrl": "https://github.com/portainer/portainer", "changelogUrl": $v.html_url }
+```
+
+- [ ] **Step 4: Verify the intended configuration values**
+
+Run:
+
+```bash
+node -e 'const c=require("./renovate.json"); if(c.minimumReleaseAgeBehaviour!=="timestamp-optional") process.exit(1); if(c.schedule?.[0]!=="* 10-13 * * 5") process.exit(1); if(!c.customDatasources["portainer-lts"].transformTemplates[0].includes("\"releaseTimestamp\": $v.published_at")) process.exit(1);'
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Validate the Renovate configuration**
+
+Run:
+
+```bash
+npx --yes --package renovate renovate-config-validator renovate.json
+```
+
+Expected: `Config validated successfully`.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add renovate.json
+git commit -m "fix: unblock timely Renovate updates" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```

--- a/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
+++ b/docs/superpowers/plans/2026-07-17-renovate-update-timing.md
@@ -53,7 +53,36 @@ node -e 'const c=require("./renovate.json"); if(c.minimumReleaseAgeBehaviour!=="
 
 Expected: exit code 0.
 
-- [ ] **Step 5: Validate the Renovate configuration**
+- [ ] **Step 5: Validate the Portainer transform against live release data**
+
+Run:
+
+```bash
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+npm install --prefix "$tmp" --silent jsonata
+NODE_PATH="$tmp/node_modules" node <<'NODE'
+const assert = require("node:assert/strict");
+const jsonata = require("jsonata");
+const config = require("./renovate.json");
+
+(async () => {
+  const response = await fetch(config.customDatasources["portainer-lts"].defaultRegistryUrlTemplate);
+  assert.equal(response.ok, true);
+  const input = await response.json();
+  const result = await jsonata(
+    config.customDatasources["portainer-lts"].transformTemplates[0],
+  ).evaluate(input);
+  const release = result.releases.find(({ version }) => version === "2.39.5");
+  assert.ok(release);
+  assert.equal(release.releaseTimestamp, "2026-07-13T22:05:35Z");
+})();
+NODE
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 6: Validate the Renovate configuration**
 
 Run:
 
@@ -63,7 +92,7 @@ npx --yes --package renovate@latest renovate-config-validator renovate.json
 
 Expected: `Config validated successfully`.
 
-- [ ] **Step 6: Commit the implementation**
+- [ ] **Step 7: Commit the implementation**
 
 ```bash
 git add renovate.json

--- a/docs/superpowers/specs/2026-07-17-renovate-update-timing-design.md
+++ b/docs/superpowers/specs/2026-07-17-renovate-update-timing-design.md
@@ -1,0 +1,15 @@
+# Renovate Update Timing Design
+
+## Goal
+
+Prevent Renovate updates from remaining indefinitely under "Pending Status Checks" while retaining the five-day release cooldown whenever a datasource supplies a release timestamp.
+
+## Design
+
+- Set `minimumReleaseAgeBehaviour` to `timestamp-optional`. Releases with timestamps must still be at least five days old; releases from sources such as GHCR that lack supported timestamps may proceed.
+- Include GitHub's `published_at` value as `releaseTimestamp` in the Portainer custom datasource transform so its LTS releases continue to honor the five-day cooldown.
+- Replace the deprecated one-hour Later schedule with the Cron schedule `* 10-13 * * 5`, allowing branch creation from 10:00 through 13:59 Pacific on Fridays. This meets Renovate's recommendation for a schedule window of at least three to four hours.
+
+## Validation
+
+Validate the configuration against Renovate's published JSON schema and confirm the JSONata transform returns Portainer releases with `version` and `releaseTimestamp`.

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "5 days",
-  "schedule": ["after 10am and before 11am on Friday"],
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "schedule": ["* 10-13 * * 5"],
   "timezone": "America/Los_Angeles",
   "packageRules": [
     {
@@ -58,7 +59,7 @@
     "portainer-lts": {
       "defaultRegistryUrlTemplate": "https://api.github.com/repos/portainer/portainer/releases?per_page=100",
       "transformTemplates": [
-        "{ \"releases\": $map($[$contains(name, \"LTS\")], function($v) { { \"version\": $v.tag_name, \"sourceUrl\": \"https://github.com/portainer/portainer\", \"changelogUrl\": $v.html_url } }) }"
+        "{ \"releases\": $map($[$contains(name, \"LTS\")], function($v) { { \"version\": $v.tag_name, \"releaseTimestamp\": $v.published_at, \"sourceUrl\": \"https://github.com/portainer/portainer\", \"changelogUrl\": $v.html_url } }) }"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- allow updates from registries without supported release timestamps while retaining the five-day cooldown where timestamps exist
- preserve Portainer GitHub release timestamps in the custom datasource
- widen the Friday Renovate schedule to a four-hour Cron window

## Test Plan
- [x] Validate `renovate.json` with Renovate 43.268.2
- [x] Evaluate the Portainer JSONata transform against live GitHub release data
- [x] Confirm the configured release-age behavior and schedule values